### PR TITLE
Update 1_ml-using-chemical-descriptors.ipynb

### DIFF
--- a/molecular-property-prediction/chemoinformatics/1_ml-using-chemical-descriptors.ipynb
+++ b/molecular-property-prediction/chemoinformatics/1_ml-using-chemical-descriptors.ipynb
@@ -299,7 +299,7 @@
     }
    ],
    "source": [
-    "desc = desc.loc[:, ~missing_values]  # Gets only rows that do not (~ means not) have missing values\n",
+    "desc = desc.loc[:, ~missing_values]  # Gets only columns that do not (~ means not) have missing values\n",
     "print(f'New shape: {desc.shape}')"
    ]
   },


### PR DESCRIPTION
When eliminating missing values, I believe we are removing columns (features) instead of removing rows (molecules), right? This did cause some confusions based on students' feedback.